### PR TITLE
Add SignColumn highlighting for syntastic

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -762,6 +762,10 @@ exe "hi! lineAdded"         .s:fmt_bold .s:fg_green  .s:bg_base02
 exe "hi! lineModified"      .s:fmt_bold .s:fg_yellow .s:bg_base02
 exe "hi! lineRemoved"       .s:fmt_bold .s:fg_red    .s:bg_base02
 " }}}
+" syntastic highlighting {{{
+exe "hi! SyntasticErrorSign"	.s:fmt_bold .s:fg_red  .s:bg_base02
+exe "hi! SyntasticWarningSign"  .s:fmt_bold .s:fg_orange .s:bg_base02
+" }}}
 " html highlighting "{{{
 " ---------------------------------------------------------------------
 exe "hi! htmlTag"           .s:fmt_none .s:fg_base01 .s:bg_none


### PR DESCRIPTION
I saw your fork fixing signcolumn for gitgutter; I use sytastic as well as gitgutter, so I added these. Hope you don't mind this PR, cheers.
